### PR TITLE
Fixing metrics on Android

### DIFF
--- a/src/android/HockeyApp.java
+++ b/src/android/HockeyApp.java
@@ -44,6 +44,8 @@ public class HockeyApp extends CordovaPlugin {
             
             FeedbackManager.register(cordova.getActivity(), appId);
             this.crashListener = new ConfiguredCrashManagerListener(autoSend, ignoreDefaultHandler);
+            
+            MetricsManager.register(cordova.getActivity(), cordova.getActivity().getApplication(), appId);
             CrashManager.register(cordova.getActivity(), appId, this.crashListener);
             
             // Verify the user


### PR DESCRIPTION
This PR fixes the metrics feature on Android by explicitly registering with the `MetricsManager` upon start, just like the crash and feedback managers do.