### PR TITLE
Build warning fix

### DIFF
--- a/src/ios/HockeyApp.h
+++ b/src/ios/HockeyApp.h
@@ -3,7 +3,7 @@
 #import "HockeyApp.h"
 #import <HockeySDK/HockeySDK.h>
 
-@interface HockeyApp : CDVPlugin <BITCrashManagerDelegate> {
+@interface HockeyApp : CDVPlugin <BITHockeyManagerDelegate> {
     BOOL initialized;
     NSMutableDictionary *crashMetaData;
 }


### PR DESCRIPTION
This addresses #27 by changing the `HockeyApp` class to use the `BITHockeyManagerDelegate` protocol instead of `BITCrashManagerDelegate`. The `BITHockeyManagerDelegate` protocol implements the `BITCrashManagerDelegate` protocol as well as a few others, all of which are composed purely of optional methods, and therefore, this change doesn't actually change any behavior or requirements of the `HockeyApp` class. It simply appeases the compiler, and makes it such that if we need to implement any additional delegate behavior in the future, we simply add the respective method to the class.

This could also be addressed by casting `self` to `id<BITHockeyManagerDelegate>` where necessary (which works since all methods on the protocol are optional, and therefore, any type would satisfy it), but I prefer this solution better. I'm open to discussing either option though, since I don't feel super strongly about it.