### PR TITLE
Fix autoSend

### DIFF
--- a/src/ios/HockeyApp.m
+++ b/src/ios/HockeyApp.m
@@ -26,7 +26,7 @@
         // no-op this for now. Appears to do nothing on ios side?
         // NSString* ignoreDefaultHandler = [arguments objectAtIndex:4];
 
-        if ([autoSend isEqual:@"true"]) {
+        if ([autoSend boolValue] == YES) {
             [[BITHockeyManager sharedHockeyManager].crashManager setCrashManagerStatus:BITCrashManagerStatusAutoSend];
         }
         


### PR DESCRIPTION
I want to resolve #48 with the following PR.
Javascript boolean values are sent as “0” or “1” to objective c. Fix the start method to read the autoSend value correctly.
