### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,18 @@
       "ios"
     ]
   },
+  "engines": {
+    "cordovaDependencies": {
+      "2.2.2": {
+        "cordova": ">=4.2.0",
+        "cordova-android": ">=4.0.0",
+        "cordova-ios": ">=3.8.0"
+      },
+      "3.0.0": {
+        "cordova": ">100"
+      }
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/bitstadium/HockeySDK-Cordova.git"


### PR DESCRIPTION
This reflects `engines` elements from plugin manifest to package.json to comply w/ [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).

It's also desirable to add 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.