### PR TITLE
Include "NSPhotoLibraryUsageDescription" for iOS10

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,9 @@
                 <param name="ios-package" value="HockeyApp" />
             </feature>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+            <string>This app needs access to your Photo Library to include a screenshot with user feedback.</string>
+        </config-file>
         <header-file src="src/ios/HockeyApp.h" />
         <source-file src="src/ios/HockeyApp.m" />
         <resource-file src="src/ios/HockeySDK.embeddedframework/HockeySDK.framework/Resources/HockeySDKResources.bundle" />


### PR DESCRIPTION
I encountered an issue when uploading to the App Store earlier today, and it complained I hadn't set the `NSPhotoLibraryUsageDescription` field in my plist file. I tracked it down to an issue with this plugin, and this fix is required for any new store submissions.

"To protect user privacy, an iOS app linked on or after iOS 10.0, and which accesses the user’s photo library, must statically declare the intent to do so."

https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html