### PR TITLE
Fix to autosend on ios

### DIFF
--- a/src/ios/HockeyApp.m
+++ b/src/ios/HockeyApp.m
@@ -28,6 +28,7 @@
 
         if ([autoSend boolValue] == YES) {
             [[BITHockeyManager sharedHockeyManager].crashManager setCrashManagerStatus:BITCrashManagerStatusAutoSend];
+            [[NSUserDefaults standardUserDefaults] setInteger:BITCrashManagerStatusAutoSend forKey:@"BITCrashManagerStatus"];
         }
         
         [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:token


### PR DESCRIPTION
The AutoSend status wasn't getting saved into UserDefaults by just setting it with the `SetCrashManagerStatus` function on the crashManager. So even when autoSend is set, the feedback popup was still showing when the app is restarted after a crash.

This fixes the issue.