### PR TITLE
Upgrade the plugin.xml to the cordova-android@7.0.0 project structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cordovaDependencies": {
       "2.2.2": {
         "cordova": ">=4.2.0",
-        "cordova-android": ">=4.0.0",
+        "cordova-android": ">=7.0.0",
         "cordova-ios": ">=3.8.0"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <issue>https://github.com/bitstadium/HockeySDK-Cordova/issues</issue>
    
     <engines>
-        <engine name="cordova-android" version=">=4.0.0" />
+        <engine name="cordova-android" version=">=7.0.0" />
         <engine name="cordova-plugman" version=">=4.2.0" />
         <engine name="cordova-ios" version=">=3.8.0" />
     </engines>
@@ -21,19 +21,19 @@
     </js-module>
     
     <platform name="android">
-        <config-file target="res/xml/config.xml" parent="/*">
+        <config-file target="app/src/main/res/xml/config.xml" parent="/*">
             <feature name="HockeyApp">
                 <param name="android-package" value="com.zengularity.cordova.hockeyapp.HockeyApp" />
             </feature>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
             <activity android:name="net.hockeyapp.android.FeedbackActivity" />
             <activity android:name="net.hockeyapp.android.UpdateActivity" />
             <activity android:name="net.hockeyapp.android.LoginActivity" />
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>


### PR DESCRIPTION
As announced [here](https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html), with the release of cordova-android@7.0.0 the project structure has changed. This means that the plugin is not compatible anymore due to the config-file statements in the plugin.xml that point to file paths that have been changed.

I updated the plugin.xml for android as advised in the documentation and increased the version of the cordova-android dependency, since the plugin won't be backwards compatible. A solution to preserve backwards compatibility might be to use wildcards in the config-file target paths, but I have not tried that. 