### PR TITLE
cordova-android 7 compability added

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <issue>https://github.com/bitstadium/HockeySDK-Cordova/issues</issue>
    
     <engines>
-        <engine name="cordova-android" version=">=4.0.0" />
+        <engine name="cordova-android" version=">=7.0.0" />
         <engine name="cordova-plugman" version=">=4.2.0" />
         <engine name="cordova-ios" version=">=3.8.0" />
     </engines>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     flatDir {
-        dirs "libs"
+        dirs "src/main/libs"
     }
 }
 


### PR DESCRIPTION
With `cordova-android@7.0.0` the location of the `libs` folder has changed to be located under `src/main/libs`.  This pull request fixes the error message returned cause the library can not found at the defined locations:

```
Could not resolve all files for configuration ':app:releaseCompileClasspath'.
> Could not find :HockeySDK-5.0.4:.
  Searched in the following locations:
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/google/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/google/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/android/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      file:/usr/local/Caskroom/android-sdk/25.2.3/extras/android/m2repository//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      https://jcenter.bintray.com//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      https://jcenter.bintray.com//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      https://maven.google.com//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      https://maven.google.com//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      https://repo1.maven.org/maven2//HockeySDK-5.0.4//HockeySDK-5.0.4-.pom
      https://repo1.maven.org/maven2//HockeySDK-5.0.4//HockeySDK-5.0.4-.aar
      file:/Users/xxx/platforms/android/app/libs/HockeySDK-5.0.4-.aar
      file:/Users/xxx/platforms/android/app/libs/HockeySDK-5.0.4.aar
  Required by:
      project :app
```